### PR TITLE
fix: send cloudformation response when lambda times out

### DIFF
--- a/cloudformation/subscribelogs.yaml.template
+++ b/cloudformation/subscribelogs.yaml.template
@@ -157,6 +157,7 @@ Resources:
               - Fn::ImportValue: !Sub "$${CollectionStackName}:logs:role:arn"
           FILTER_NAME: !Ref FilterName
           FILTER_PATTERN: !Ref FilterPattern
+          TIMEOUT: !Ref LambdaTimeout
       Runtime: python3.9
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ locals {
     "DELIVERY_STREAM_ROLE_ARN" = local.subscription_filter_role_arn
     "FILTER_NAME"              = var.filter_name
     "FILTER_PATTERN"           = var.filter_pattern
+    "TIMEOUT"                  = var.lambda_timeout
 
     # Bump VERSION if we want to re-create the subscription filters even
     # if the user's environment variables haven't changed.


### PR DESCRIPTION
This is for
https://observe.atlassian.net/browse/OB-12739?focusedCommentId=52189.

This addresses it by introducing a 2nd thread which sends a cfn response 5 seconds before the lambda times out.
This is similar to the AWS recommended approach: https://github.com/stelligent/cloudformation-custom-resources/blob/master/lambda/python/customresource.py