### PR TITLE
chore: fix make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ precommit-dependencies:
 
 .PHONY: test
 test:
+	terraform -chdir=./cloudformation init
+	terraform -chdir=./cloudformation apply -auto-approve
 	pre-commit run
 	python3 ./lambda/test_index.py
 


### PR DESCRIPTION
The target would fail if you didn't generate the cloudformation first.