### PR TITLE
docs: clarify `filter_pattern` usage

### DIFF
--- a/cloudformation/subscribelogs.yaml.template
+++ b/cloudformation/subscribelogs.yaml.template
@@ -20,7 +20,7 @@ Parameters:
     Type: "String"
     Default: ""
     Description: >-
-      The filter pattern to use. For more information, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
+      The filter pattern that selects the log events that will be sent to Observe for each CloudWatch Logs group. To send all events, leave this empty (""). For more information, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html.
   FilterName:
     Type: "String"
     Default: "observe-logs-subscription"

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "log_group_excludes" {
 
 variable "filter_pattern" {
   description = <<-EOF
-    The filter pattern to use. For more information, see [Filter and Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html)"
+    The filter pattern that selects the log events that will be sent to Observe for each CloudWatch Logs group. To send all events, leave this empty (""). For more information, see [Filter and Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html).
   EOF
   type        = string
   default     = ""


### PR DESCRIPTION
Clarifies how to use `filter_pattern`/`FilterPattern`—generally, don't. 

Since this module touches many log groups, it would be inherently difficult to craft a filter pattern suitable for all of those groups. In theory, users might deploy multiple copies of this module, each matching a different set of log groups, in order to target a filter pattern at a smaller number of groups.

So while we should still provide the option to set this, I've further clarified that you should leave it empty to send everything. Otherwise, users are liable to see that it's required but empty and guess at some inevitably incorrect value.